### PR TITLE
🐛 Bug - TinyMCE apiKey fixed

### DIFF
--- a/src/conf/conf.js
+++ b/src/conf/conf.js
@@ -4,7 +4,7 @@ const conf = {
     appwriteDatabaseId: String(import.meta.env.VITE_APPWRITE_DATABASE_ID),
     appwriteCollectionId: String(import.meta.env.VITE_APPWRITE_COLLECTION_ID),
     appwriteBucketId: String(import.meta.env.VITE_APPWRITE_BUCKET_ID),
-    RTEapiKey: String(import.meta.env.RTE_API_KEY)
+    RTEapiKey: String(import.meta.env.VITE_RTE_API_KEY)
 }
 
 export default conf


### PR DESCRIPTION
# Pull Request

## Description
To continue using TinyMCE, API key is required from starting 2024 so I added the API key.

## Changes Made
List of changes made in this pull request.

- Added API key for content maker in add-post section.

## Screenshot
![TinyMCE API key](https://github.com/2003tanmay/appwriteblog/assets/91016907/5a465c40-eead-4320-b959-55bcb1782abb)

## Checklist
- [x] I have reviewed my code for any potential issues
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (if applicable)
- [ ] My changes pass the automated tests

## Additional Notes
This issue is originated in content of add-post section.

## Dependencies
Added API key in Environment variable.

## Related Pull Requests
None.